### PR TITLE
Add option for all derived types in XmlParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ You can create a tab in the Analyzer specifically for your mod ahead of time by 
         <NestedTypes>
             <li>Verse.ThreadLocalDeepProfiler</li> 
         </NestedTypes>
+        <DerivedTypes>
+            <li>RimWorld.Need</li> 
+        </DerivedTypes>
     </tabName>
 </Analyzer>
 ```
-This will create a tab titled `tabName` which will profile all the methods in the type `Verse.Pawn` and the method `Verse.Thing:Tick`. It will also profile all methods implemented in the nested types of `Verse.ThreadLocalDeepProfiler`. Primary use-case for the nested classes being nested harmony-patch classes.
+This will create a tab titled `tabName` which will profile all the methods in the type `Verse.Pawn` and the method `Verse.Thing:Tick`. It will also profile all methods implemented in the nested types of `Verse.ThreadLocalDeepProfiler`, and all methods implemented in ``RimWorld.Need`` as well as any derived types. Primary use-case for the nested classes being nested harmony-patch classes.
 
 This file should be placed in the root directory of your mod. If you wish to avoid cluttering the Analyzer for end users, remember to remove it before releasing to steam. However, you might also decide to keep it in to allow users to easily see how your mod performs, to pre-emptively counter complaints.
 

--- a/Source/Profiling/Utility/XmlParser.cs
+++ b/Source/Profiling/Utility/XmlParser.cs
@@ -61,6 +61,10 @@ namespace Analyzer.Profiling
                         case "nestedtypes":
                             foreach (XmlNode type in child.ChildNodes)
                                 meths.AddRange(ParseSubTypeTypeMethods(type.InnerText)); break;
+                        case "derivedtype":
+                        case "derivedtypes":
+                            foreach (XmlNode type in child.ChildNodes)
+                                meths.AddRange(ParseDerivedTypeMethods(type.InnerText)); break;
                         default:
                             ThreadSafeLogger.Error($"[Analyzer] Attempting to read unknown value from an Analyzer.xml, the given input was {child.Name}, it should have been either '(M/m)ethods', '(T/t)ypes' '(N/n)estedTypes");
                             break;
@@ -91,6 +95,23 @@ namespace Analyzer.Profiling
 
             foreach(var subType in type.GetNestedTypes())
                 foreach(var method in Utility.GetTypeMethods(subType))
+                    yield return method;
+        }
+
+        private static IEnumerable<MethodInfo> ParseDerivedTypeMethods(string str)
+        {
+            var type = AccessTools.TypeByName(str);
+            if (type == null)
+                yield break;
+
+            if (type == typeof(object))
+            {
+                ThreadSafeLogger.Error("[Analyzer] Attempting to parse derived types of object, which is all reference types.");
+                yield break;
+            }    
+
+            foreach (var derivedType in AccessTools.AllTypes().Where(type.IsAssignableFrom))
+                foreach (var method in Utility.GetTypeMethods(derivedType))
                     yield return method;
         }
     }

--- a/Source/Profiling/Utility/XmlParser.cs
+++ b/Source/Profiling/Utility/XmlParser.cs
@@ -66,7 +66,7 @@ namespace Analyzer.Profiling
                             foreach (XmlNode type in child.ChildNodes)
                                 meths.AddRange(ParseDerivedTypeMethods(type.InnerText)); break;
                         default:
-                            ThreadSafeLogger.Error($"[Analyzer] Attempting to read unknown value from an Analyzer.xml, the given input was {child.Name}, it should have been either '(M/m)ethods', '(T/t)ypes' '(N/n)estedTypes");
+                            ThreadSafeLogger.Error($"[Analyzer] Attempting to read unknown value from an Analyzer.xml, the given input was {child.Name}, it should have been either '(M/m)ethods', '(T/t)ypes', '(N/n)estedTypes', '(D/d)erivedTypes'");
                             break;
                     }
                 }


### PR DESCRIPTION
This is useful to people like me who have my custom base class, lots of derived classes, the desire to track all of their performance, and the laziness to not wanting to add each of them individually.  

Perhaps it'd also be nice to add an option to simply include all methods under a namespace or assembly ...  