### PR TITLE
Fix annoying bug when trying to profile internal methods

### DIFF
--- a/Source/Profiling/Utility/ProfilingUtility/Utility.cs
+++ b/Source/Profiling/Utility/ProfilingUtility/Utility.cs
@@ -388,6 +388,14 @@ namespace Analyzer.Profiling
         {
             if (InternalMethodUtility.PatchedInternals.Contains(method))
             {
+                var guiEntryStr = method.DeclaringType + ":" + method.Name + "-int";
+                Entry entry = GUIController.EntryByName(guiEntryStr);
+                if (entry != null)
+                { 
+                    GUIController.SwapToEntry(guiEntryStr);
+                    return;
+                }
+
                 var ms = GetSignature(method, true);
                 Messages.Message($"Have already patched the method {ms}", MessageTypeDefOf.CautionInput, false);
                 Warn($"Trying to re-transpile an already profiled internal method - {ms}");


### PR DESCRIPTION
I found this to be particularly inconvenient while profiling my own mod. When profiling internal methods twice, instead of failing we can just automatically locate and switch to the existing GUI entry for the already patched method.

https://github.com/user-attachments/assets/838ff9b6-6451-4271-9c1d-6d1be63a3b66


Over time, the GUI becomes overbloated with internal method entries, making it difficult to search for a specific one. This can be easily fixed